### PR TITLE
Opravena chyba v příkladech bencode_check

### DIFF
--- a/u2/README.md
+++ b/u2/README.md
@@ -153,7 +153,7 @@ ld1:ai1e1:bi2eed1:ai3e1:c1:dee
 
 Tento bencode není OK kvůli kolizi typů na položce `b`:
 ```
-ld1:ai1e1:bi2eed1:ai3e1:c1:dee
+ld1:ai1e1:bi2eed1:ai3e1:b1:dee
 ```
 
 Tento bencode je OK:


### PR DESCRIPTION
Procházející i neprocházející příklady byly stejné.

Neprocházející příklad měl být podle textu pravděpodobně takovýto:
```json
[
    {
        "a": 1,
        "b": 2
    },
    {
        "a": 3,
        "b": "d"
    }
]
```